### PR TITLE
Allow configuration for messages webhooks

### DIFF
--- a/src/datasources/migrations/1694512065902-SendMessages.ts
+++ b/src/datasources/migrations/1694512065902-SendMessages.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SendMessages1694512065902 implements MigrationInterface {
+  name = 'SendMessages1694512065902';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "webhook" ADD "sendMessages" boolean NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "webhook" DROP COLUMN "sendMessages"`);
+  }
+}

--- a/src/routes/webhook/entities/webhook.entity.spec.ts
+++ b/src/routes/webhook/entities/webhook.entity.spec.ts
@@ -20,6 +20,7 @@ describe('Webhook entity', () => {
     webhook.sendTokenTransfers = true;
     webhook.sendModuleTransactions = true;
     webhook.sendSafeCreations = true;
+    webhook.sendMessages = true;
   });
 
   it('If chain is set, only those chain messages will be sent', async () => {
@@ -103,6 +104,20 @@ describe('Webhook entity', () => {
     txServiceEvent.type = 'SAFE_CREATED' as TxServiceEventType;
     expect(webhook.isEventRelevant(txServiceEvent)).toBe(true);
     webhook.sendSafeCreations = false;
+    expect(webhook.isEventRelevant(txServiceEvent)).toBe(false);
+  });
+
+  it('MESSAGE_CREATED should not be relevant if sendMessages is disabled', async () => {
+    txServiceEvent.type = 'MESSAGE_CREATED' as TxServiceEventType;
+    expect(webhook.isEventRelevant(txServiceEvent)).toBe(true);
+    webhook.sendMessages = false;
+    expect(webhook.isEventRelevant(txServiceEvent)).toBe(false);
+  });
+
+  it('MESSAGE_CONFIRMATION should not be relevant if sendMessages is disabled', async () => {
+    txServiceEvent.type = 'MESSAGE_CONFIRMATION' as TxServiceEventType;
+    expect(webhook.isEventRelevant(txServiceEvent)).toBe(true);
+    webhook.sendMessages = false;
     expect(webhook.isEventRelevant(txServiceEvent)).toBe(false);
   });
 });

--- a/src/routes/webhook/entities/webhook.entity.ts
+++ b/src/routes/webhook/entities/webhook.entity.ts
@@ -39,6 +39,9 @@ export class Webhook extends BaseEntity {
   @Column({ default: true })
   sendSafeCreations: boolean;
 
+  @Column({ default: true })
+  sendMessages: boolean;
+
   /**
    * Check if event chainId matches the one of the webhook (everything will match if webhook chains are empty). Check if event
    * type matches the flags enabled for the webhook
@@ -46,8 +49,10 @@ export class Webhook extends BaseEntity {
    * @returns true if event is relevant.
    */
   isEventRelevant(message: TxServiceEvent): boolean {
+    const chainMatches: boolean =
+      this.chains.length === 0 || this.chains.includes(message.chainId);
     return (
-      (this.chains.length === 0 || this.chains.includes(message.chainId)) &&
+      chainMatches &&
       ((this.sendConfirmations &&
         (message.type === 'NEW_CONFIRMATION' ||
           message.type === 'CONFIRMATION_REQUEST')) ||
@@ -62,6 +67,9 @@ export class Webhook extends BaseEntity {
             message.type === 'OUTGOING_TOKEN')) ||
         (this.sendModuleTransactions &&
           message.type === 'MODULE_TRANSACTION') ||
+        (this.sendMessages &&
+          (message.type === 'MESSAGE_CREATED' ||
+            message.type === 'MESSAGE_CONFIRMATION')) ||
         (this.sendSafeCreations && message.type === 'SAFE_CREATED'))
     );
   }


### PR DESCRIPTION
- Add a new `sendMessages` field to WebHook database table
