### PR TITLE
Add authentication for SSE endpoint

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,4 +6,5 @@ ADMIN_EMAIL=admin@safe
 ADMIN_PASSWORD=password
 WEBHOOKS_CACHE_TTL=300000
 NODE_ENV=dev
-#URL_BASE_PATH=/test  # Set a globlal url path 
+SSE_AUTH_TOKEN=aW5mcmFAc2FmZS5nbG9iYWw6YWJjMTIz
+# URL_BASE_PATH=/test  # Set a globlal url path

--- a/README.md
+++ b/README.md
@@ -185,5 +185,5 @@ Available endpoints:
 
 - /health/ -> Check health for the service.
 - /admin/ -> Admin panel to edit database models.
-- /events/sse/{CHECKSUMMED_SAFE_ADDRESS} -> Server side events endpoint. If `SSE_AUTH_TOKEN` is defined authentication
+- /events/sse/{CHECKSUMMED_SAFE_ADDRESS} -> Server side events endpoint. If `SSE_AUTH_TOKEN` is defined then authentication
   will be enabled and header `Authorization: Basic $SSE_AUTH_TOKEN` must be added to the request.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Some parameters are common to every event:
 }
 ```
 
-### Message created/confirmed 
+### Message created/confirmed
+
 ```json
 {
 "address": "<Ethereum checksummed address>",
@@ -147,11 +148,13 @@ cp .env.sample .env
 ```
 
 Simple way:
+
 ```bash
 bash ./scripts/run_tests.sh
 ```
 
 Manual way:
+
 ```bash
 docker compose down
 docker compose up -d rabbitmq db db-migrations
@@ -182,3 +185,5 @@ Available endpoints:
 
 - /health/ -> Check health for the service.
 - /admin/ -> Admin panel to edit database models.
+- /events/sse/{CHECKSUMMED_SAFE_ADDRESS} -> Server side events endpoint. If `SSE_AUTH_TOKEN` is defined authentication
+  will be enabled and header `Authorization: Basic $SSE_AUTH_TOKEN` must be added to the request.

--- a/src/auth/basic-auth.guard.ts
+++ b/src/auth/basic-auth.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class BasicAuthGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean | Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const token = this.configService.get('SSE_AUTH_TOKEN', '');
+    // If token is not set, authentication is disabled
+    return (
+      token === '' || request.headers['authorization'] === `Basic ${token}`
+    );
+  }
+}

--- a/src/routes/events/events.controller.spec.ts
+++ b/src/routes/events/events.controller.spec.ts
@@ -1,11 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { EventsController } from './events.controller';
 import { EventsService } from './events.service';
 import { QueueProvider } from '../../datasources/queue/queue.provider';
 import { WebhookService } from '../webhook/webhook.service';
 import { firstValueFrom } from 'rxjs';
 import { TxServiceEvent, TxServiceEventType } from './event.dto';
-import { BadRequestException } from '@nestjs/common';
 
 describe('EventsController', () => {
   let controller: EventsController;
@@ -13,6 +14,7 @@ describe('EventsController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot()],
       controllers: [EventsController],
       providers: [EventsService, QueueProvider, WebhookService],
     })

--- a/src/routes/events/events.controller.ts
+++ b/src/routes/events/events.controller.ts
@@ -1,12 +1,22 @@
-import { BadRequestException, Controller, Param, Sse } from '@nestjs/common';
+import {
+  BadRequestException,
+  Controller,
+  Param,
+  Sse,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { Observable } from 'rxjs';
 import { EventsService } from './events.service';
 import { getAddress, isAddress } from 'ethers';
+import { BasicAuthGuard } from '../../auth/basic-auth.guard';
 
+@ApiTags('events')
 @Controller('events')
 export class EventsController {
   constructor(private readonly eventsService: EventsService) {}
 
+  @UseGuards(BasicAuthGuard)
   @Sse('/sse/:safe')
   sse(@Param('safe') safe: string): Observable<MessageEvent> {
     if (isAddress(safe) && getAddress(safe) === safe)

--- a/src/routes/events/events.module.ts
+++ b/src/routes/events/events.module.ts
@@ -3,9 +3,10 @@ import { EventsController } from './events.controller';
 import { EventsService } from './events.service';
 import { QueueModule } from '../../datasources/queue/queue.module';
 import { WebhookModule } from '../webhook/webhook.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
-  imports: [QueueModule, WebhookModule],
+  imports: [QueueModule, WebhookModule, ConfigModule],
   controllers: [EventsController],
   providers: [EventsService],
 })


### PR DESCRIPTION
- It can be set by `SSE_AUTH_TOKEN` environment variable. If not defined, it will be disabled
- Update tests
- Add info about endpoint to README
