### PR TITLE
Add configuration for SSL database connection

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,4 +7,6 @@ ADMIN_PASSWORD=password
 WEBHOOKS_CACHE_TTL=300000
 NODE_ENV=dev
 SSE_AUTH_TOKEN=aW5mcmFAc2FmZS5nbG9iYWw6YWJjMTIz
+ENABLE_DB_SSL=false
+# DB_CA_PATH=/path/of/db/certificate
 # URL_BASE_PATH=/test  # Set a globlal url path

--- a/src/datasources/db/database.options.ts
+++ b/src/datasources/db/database.options.ts
@@ -1,5 +1,6 @@
 import { Webhook } from '../../routes/webhook/entities/webhook.entity';
 import { DataSourceOptions } from 'typeorm';
+import * as fs from 'fs';
 
 /**
  * Use process.env for configuration instead of Nest.js ConfigService
@@ -10,4 +11,23 @@ export const dataSourceOptions: DataSourceOptions = {
   url: process.env.MIGRATIONS_DATABASE_URL,
   entities: [Webhook],
   migrations: [__dirname + '/../migrations/**/*{.ts,.js}'],
+  ... (process.env.DB_SSL_ENABLE == 'true' ? { 
+    ssl: true,
+    ... (process.env.DB_CA_PATH ? {
+      extra: {
+        ssl: {
+          ca: fs.readFileSync(process.env.DB_CA_PATH),
+          rejectUnauthorized: true
+        }
+      }
+    } : {
+      extra: {
+        ssl: {
+          rejectUnauthorized: false
+        }
+      }
+    })
+  }:{
+    ssl: false
+  })
 };


### PR DESCRIPTION
# Description
This PR adds the needed configuration to enable SSL connection with database and optional configuration of database certificates. 

# New environment vars
`DB_SSL_ENABLE` if is unset or false SSL won't be used but if true then the connection will use SSL.
`DB_CA_PATH` path of database certificate, when is configured the connection will validate the database certificate during the connection. 