### PR TITLE
Increase DB health check timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   web:
     build:

--- a/src/datasources/queue/queue.health.ts
+++ b/src/datasources/queue/queue.health.ts
@@ -8,7 +8,7 @@ import { QueueProvider } from './queue.provider';
 
 @Injectable()
 export class QueueHealthIndicator extends HealthIndicator {
-  constructor(private queueProvider: QueueProvider) {
+  constructor(private readonly queueProvider: QueueProvider) {
     super();
   }
 

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -12,7 +12,7 @@ describe('HealthController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [HealthModule, ConfigModule.forRoot(), DatabaseModule],
+      imports: [ConfigModule.forRoot(), HealthModule, DatabaseModule],
     }).compile();
 
     controller = module.get<HealthController>(HealthController);

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import {
   HealthCheckService,
   HealthCheck,
@@ -11,16 +12,20 @@ import { ApiTags } from '@nestjs/swagger';
 @Controller('health')
 export class HealthController {
   constructor(
-    private health: HealthCheckService,
-    private db: TypeOrmHealthIndicator,
-    private queue: QueueHealthIndicator,
+    private readonly configService: ConfigService,
+    private readonly health: HealthCheckService,
+    private readonly db: TypeOrmHealthIndicator,
+    private readonly queue: QueueHealthIndicator,
   ) {}
 
   @Get()
   @HealthCheck()
   check() {
     return this.health.check([
-      () => this.db.pingCheck('database'),
+      () =>
+        this.db.pingCheck('database', {
+          timeout: this.configService.get('DB_HEALTH_CHECK_TIMEOUT', 5000),
+        }),
       () => this.queue.isHealthy('queue'),
     ]);
   }

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { HealthController } from './health.controller';
 import { TerminusModule } from '@nestjs/terminus';
 import { QueueModule } from '../datasources/queue/queue.module';
 
 @Module({
-  imports: [TerminusModule, QueueModule],
+  imports: [ConfigModule, TerminusModule, QueueModule],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/src/routes/events/events.service.ts
+++ b/src/routes/events/events.service.ts
@@ -12,7 +12,6 @@ export class EventsService implements OnApplicationBootstrap {
 
   constructor(
     private readonly queueProvider: QueueProvider,
-
     private readonly webhookService: WebhookService,
   ) {}
 


### PR DESCRIPTION
- Set 5 seconds as the default
- Timeout can now be set using `DB_HEALTH_CHECK_TIMEOUT` environment variable
