### PR TITLE
Add events log as JSON

### DIFF
--- a/src/logging/json-logger.spec.ts
+++ b/src/logging/json-logger.spec.ts
@@ -15,13 +15,13 @@ describe('JsonLogger', () => {
       timestamp: false,
     });
 
-    expect(dateNowSpy).toBeCalledTimes(0);
-    expect(consoleLogSpy).toBeCalledTimes(0);
+    expect(dateNowSpy).toHaveBeenCalledTimes(0);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(0);
     consoleLogger.debug('test');
     // Internal logger Date.now() and our Date.now() call
-    expect(dateNowSpy).toBeCalledTimes(2);
-    expect(consoleLogSpy).toBeCalledTimes(1);
-    expect(consoleLogSpy).toBeCalledWith(
+    expect(dateNowSpy).toHaveBeenCalledTimes(2);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
       '{"timestamp":"2000-05-19T00:00:00.000Z","context":"JsonLoggerTest","level":"debug","message":"test"}\n',
     );
   });
@@ -30,16 +30,18 @@ describe('JsonLogger', () => {
       timestamp: false,
     });
 
-    //dateNowSpy.mockClear()
-    //consoleLogSpy.mockClear()
-    expect(dateNowSpy).toBeCalledTimes(0);
-    expect(consoleLogSpy).toBeCalledTimes(0);
-    consoleLogger.debug({ message: 'testJSON', event: { chainId: 1 } });
+    expect(dateNowSpy).toHaveBeenCalledTimes(0);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(0);
+    consoleLogger.debug({
+      message: 'testJSON',
+      event: { chainId: 1 },
+      anotherField: 'test',
+    });
     // Internal logger Date.now() and our Date.now() call
-    expect(dateNowSpy).toBeCalledTimes(2);
-    expect(consoleLogSpy).toBeCalledTimes(1);
-    expect(consoleLogSpy).toBeCalledWith(
-      '{"timestamp":"2000-05-19T00:00:00.000Z","context":"JsonLoggerTest","level":"debug","message":"testJSON","event":{"chainId":1}}\n',
+    expect(dateNowSpy).toHaveBeenCalledTimes(2);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '{"timestamp":"2000-05-19T00:00:00.000Z","context":"JsonLoggerTest","level":"debug","message":"testJSON","event":{"chainId":1},"anotherField":"test"}\n',
     );
   });
 });

--- a/src/logging/json-logger.spec.ts
+++ b/src/logging/json-logger.spec.ts
@@ -18,6 +18,7 @@ describe('JsonLogger', () => {
     expect(dateNowSpy).toHaveBeenCalledTimes(0);
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
     consoleLogger.debug('test');
+
     // Internal logger Date.now() and our Date.now() call
     expect(dateNowSpy).toHaveBeenCalledTimes(2);
     expect(consoleLogSpy).toHaveBeenCalledTimes(1);
@@ -34,14 +35,19 @@ describe('JsonLogger', () => {
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
     consoleLogger.debug({
       message: 'testJSON',
-      event: { chainId: 1 },
-      anotherField: 'test',
+      messageContext: {
+        event: { chainId: 1 },
+        anotherField: 'test',
+      },
+      ignoredAttribute:
+        'Everything not on message or messageContext is ignored',
     });
+
     // Internal logger Date.now() and our Date.now() call
     expect(dateNowSpy).toHaveBeenCalledTimes(2);
     expect(consoleLogSpy).toHaveBeenCalledTimes(1);
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      '{"timestamp":"2000-05-19T00:00:00.000Z","context":"JsonLoggerTest","level":"debug","message":"testJSON","event":{"chainId":1},"anotherField":"test"}\n',
+      '{"timestamp":"2000-05-19T00:00:00.000Z","context":"JsonLoggerTest","level":"debug","messageContext":{"event":{"chainId":1},"anotherField":"test"}}\n',
     );
   });
 });

--- a/src/logging/json-logger.spec.ts
+++ b/src/logging/json-logger.spec.ts
@@ -1,14 +1,19 @@
 import { JsonConsoleLogger } from './json-logger';
 
+const consoleLogSpy = jest.spyOn(process.stdout, 'write');
+const dateNowSpy = jest
+  .spyOn(Date, 'now')
+  .mockImplementation(() => 958694400000);
+
 describe('JsonLogger', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should return a stringified JSON', async () => {
     const consoleLogger = new JsonConsoleLogger('JsonLoggerTest', {
       timestamp: false,
     });
-    const consoleLogSpy = jest.spyOn(process.stdout, 'write');
-    const dateNowSpy = jest
-      .spyOn(Date, 'now')
-      .mockImplementation(() => 958694400000);
 
     expect(dateNowSpy).toBeCalledTimes(0);
     expect(consoleLogSpy).toBeCalledTimes(0);
@@ -18,6 +23,23 @@ describe('JsonLogger', () => {
     expect(consoleLogSpy).toBeCalledTimes(1);
     expect(consoleLogSpy).toBeCalledWith(
       '{"timestamp":"2000-05-19T00:00:00.000Z","context":"JsonLoggerTest","level":"debug","message":"test"}\n',
+    );
+  });
+  it('should return a stringified JSON for a JSON message', async () => {
+    const consoleLogger = new JsonConsoleLogger('JsonLoggerTest', {
+      timestamp: false,
+    });
+
+    //dateNowSpy.mockClear()
+    //consoleLogSpy.mockClear()
+    expect(dateNowSpy).toBeCalledTimes(0);
+    expect(consoleLogSpy).toBeCalledTimes(0);
+    consoleLogger.debug({ message: 'testJSON', event: { chainId: 1 } });
+    // Internal logger Date.now() and our Date.now() call
+    expect(dateNowSpy).toBeCalledTimes(2);
+    expect(consoleLogSpy).toBeCalledTimes(1);
+    expect(consoleLogSpy).toBeCalledWith(
+      '{"timestamp":"2000-05-19T00:00:00.000Z","context":"JsonLoggerTest","level":"debug","message":"testJSON","event":{"chainId":1}}\n',
     );
   });
 });

--- a/src/logging/json-logger.ts
+++ b/src/logging/json-logger.ts
@@ -1,4 +1,17 @@
 import { ConsoleLogger, LogLevel } from '@nestjs/common';
+import { TxServiceEvent } from '../routes/events/event.dto';
+
+interface JsonEventMessage {
+  message: string;
+  event: TxServiceEvent;
+}
+
+function isJsonEventMessage(message: unknown): message is JsonEventMessage {
+  const messageCasted = message as JsonEventMessage;
+  return (
+    messageCasted.message !== undefined && messageCasted.message !== undefined
+  );
+}
 
 export class JsonConsoleLogger extends ConsoleLogger {
   protected formatPid(pid: number) {
@@ -23,15 +36,20 @@ export class JsonConsoleLogger extends ConsoleLogger {
     contextMessage: string,
     // timestampDiff: string,
   ): string {
-    const output = this.stringifyMessage(message, logLevel);
     const timestamp = Date.now();
     const dateAsString = new Date(timestamp).toISOString();
-    const logJson = {
+    const logJson: any = {
       timestamp: dateAsString,
       context: contextMessage,
       level: logLevel,
-      message: output,
     };
+    if (isJsonEventMessage(message)) {
+      logJson.message = message.message;
+      logJson.event = message.event;
+    } else {
+      logJson.message = this.stringifyMessage(message, logLevel);
+    }
+
     return `${JSON.stringify(logJson)}\n`;
   }
 }

--- a/src/logging/json-logger.ts
+++ b/src/logging/json-logger.ts
@@ -1,11 +1,18 @@
 import { ConsoleLogger, LogLevel } from '@nestjs/common';
 
 /**
- * All the fields provided will be part of the JSON log (instead of a stringified JSON)
+ * Fields provided will be part of the messageContext field for the JSON log
+ */
+interface MessageContext {
+  [otherProperties: string]: string;
+}
+
+/**
+ * JSON log structure
  */
 interface JsonEventMessage {
   message: string;
-  [otherProperties: string]: unknown;
+  messageContext: MessageContext;
 }
 
 export class JsonConsoleLogger extends ConsoleLogger {
@@ -33,7 +40,7 @@ export class JsonConsoleLogger extends ConsoleLogger {
   ): string {
     const timestamp = Date.now();
     const dateAsString = new Date(timestamp).toISOString();
-    let logJson: any = {
+    const logJson: any = {
       timestamp: dateAsString,
       context: contextMessage,
       level: logLevel,
@@ -41,7 +48,7 @@ export class JsonConsoleLogger extends ConsoleLogger {
     if (typeof message === 'string') {
       logJson.message = this.stringifyMessage(message, logLevel);
     } else {
-      logJson = { ...logJson, ...message };
+      logJson.messageContext = message.messageContext;
     }
 
     return `${JSON.stringify(logJson)}\n`;

--- a/src/routes/events/events.service.spec.ts
+++ b/src/routes/events/events.service.spec.ts
@@ -58,10 +58,10 @@ describe('EventsService', () => {
         address: '0x0275FC2adfF11270F3EcC4D2F7Aa0a9784601Ca6',
       };
       await eventsService.processEvent(JSON.stringify(msg));
-      expect(postEveryWebhook).toBeCalledTimes(1);
-      expect(postEveryWebhook).toBeCalledWith(msg);
-      expect(pushEventToEventsObservable).toBeCalledTimes(1);
-      expect(pushEventToEventsObservable).toBeCalledWith(msg);
+      expect(postEveryWebhook).toHaveBeenCalledTimes(1);
+      expect(postEveryWebhook).toHaveBeenCalledWith(msg);
+      expect(pushEventToEventsObservable).toHaveBeenCalledTimes(1);
+      expect(pushEventToEventsObservable).toHaveBeenCalledWith(msg);
     });
   });
 
@@ -85,11 +85,11 @@ describe('EventsService', () => {
       };
 
       await eventsService.processEvent(JSON.stringify(messageCreated));
-      expect(postEveryWebhook).toBeCalledTimes(1);
-      expect(postEveryWebhook).toBeCalledWith(messageCreated);
+      expect(postEveryWebhook).toHaveBeenCalledTimes(1);
+      expect(postEveryWebhook).toHaveBeenCalledWith(messageCreated);
       await eventsService.processEvent(JSON.stringify(messageConfirmation));
-      expect(postEveryWebhook).toBeCalledTimes(2);
-      expect(postEveryWebhook).toBeCalledWith(messageConfirmation);
+      expect(postEveryWebhook).toHaveBeenCalledTimes(2);
+      expect(postEveryWebhook).toHaveBeenCalledWith(messageConfirmation);
     });
   });
 });

--- a/src/routes/events/events.service.ts
+++ b/src/routes/events/events.service.ts
@@ -68,10 +68,13 @@ export class EventsService implements OnApplicationBootstrap {
   }
 
   processEvent(message: string): Promise<(AxiosResponse | undefined)[]> {
-    this.logger.log(`Processing event ${message}`);
     let txServiceEvent: TxServiceEvent;
     try {
       txServiceEvent = JSON.parse(message);
+      this.logger.log({
+        message: `Processing event`,
+        event: txServiceEvent,
+      });
     } catch (err) {
       this.logger.error(`Cannot parse message as JSON: ${message}`);
       return Promise.resolve([undefined]);

--- a/src/routes/webhook/webhook.service.spec.ts
+++ b/src/routes/webhook/webhook.service.spec.ts
@@ -221,15 +221,17 @@ describe('Webhook service', () => {
         headers: {},
       });
       expect(loggerErrorSpy).toHaveBeenCalledWith({
-        event: event,
         message: 'Error sending event',
-        httpRequest: {
-          startTime: expect.any(Number),
-          url: url,
-        },
-        httpResponse: {
-          data: axiosResponseMocked.data,
-          statusCode: axiosResponseMocked.status,
+        messageContext: {
+          event: event,
+          httpRequest: {
+            startTime: expect.any(Number),
+            url: url,
+          },
+          httpResponse: {
+            data: axiosResponseMocked.data,
+            statusCode: axiosResponseMocked.status,
+          },
         },
       });
     });
@@ -274,12 +276,14 @@ describe('Webhook service', () => {
       });
       expect(loggerErrorSpy).toHaveBeenCalledWith({
         message: `Error sending event: Response not received. Error: ${errorMessageMocked}`,
-        event: event,
-        httpRequest: {
-          url: url,
-          startTime: expect.any(Number),
+        messageContext: {
+          event: event,
+          httpRequest: {
+            url: url,
+            startTime: expect.any(Number),
+          },
+          httpResponse: null,
         },
-        httpResponse: null,
       });
     });
 
@@ -309,12 +313,14 @@ describe('Webhook service', () => {
       });
       expect(loggerErrorSpy).toHaveBeenCalledWith({
         message: `Error sending event: ${errorMessage}`,
-        event: event,
-        httpRequest: {
-          url: url,
-          startTime: expect.any(Number),
+        messageContext: {
+          event: event,
+          httpRequest: {
+            url: url,
+            startTime: expect.any(Number),
+          },
+          httpResponse: null,
         },
-        httpResponse: null,
       });
     });
 
@@ -347,17 +353,19 @@ describe('Webhook service', () => {
         headers: {},
       });
       expect(loggerErrorSpy).toHaveBeenCalledWith({
-        event: event,
         message: 'Success sending event',
-        httpRequest: {
-          endTime: expect.any(Number),
-          startTime: expect.any(Number),
-          url: url,
-        },
-        httpResponse: {
-          data: 'null',
-          elapsedTimeMs: 0,
-          statusCode: 204,
+        messageContext: {
+          event: event,
+          httpRequest: {
+            endTime: expect.any(Number),
+            startTime: expect.any(Number),
+            url: url,
+          },
+          httpResponse: {
+            data: 'null',
+            elapsedTimeMs: 0,
+            statusCode: 204,
+          },
         },
       });
     });

--- a/src/routes/webhook/webhook.service.spec.ts
+++ b/src/routes/webhook/webhook.service.spec.ts
@@ -176,7 +176,7 @@ describe('Webhook service', () => {
 
     it('should log an error message if response is received with non-2xx status code', async () => {
       const url = 'http://localhost:4815';
-      const msg = {
+      const event = {
         chainId: '1',
         type: 'SAFE_CREATED' as TxServiceEventType,
         text: 'hello',
@@ -210,26 +210,27 @@ describe('Webhook service', () => {
         .spyOn(Logger.prototype, 'error')
         .mockImplementation();
 
-      await webhookService.postWebhook(msg, url, '');
+      await webhookService.postWebhook(event, url, '');
 
       expect(httpServicePostSpy).toHaveBeenCalledTimes(1);
-      expect(httpServicePostSpy).toHaveBeenCalledWith(url, msg, {
+      expect(httpServicePostSpy).toHaveBeenCalledWith(url, event, {
         headers: {},
       });
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `Error sending event ${JSON.stringify(msg)} to ${url}: ${
+      expect(loggerErrorSpy).toHaveBeenCalledWith({
+        event: event,
+        message: expect.stringContaining(
+          `Error sending event to ${url}: ${
             axiosResponseMocked.status
           } ${axiosResponseMocked.statusText} - ${JSON.stringify(
             axiosResponseMocked.data,
           )}`,
         ),
-      );
+      });
     });
 
     it('should log an error message if response is not received', async () => {
       const url = 'http://localhost:4815';
-      const msg = {
+      const event = {
         chainId: '1',
         type: 'SAFE_CREATED' as TxServiceEventType,
         text: 'hello',
@@ -259,24 +260,23 @@ describe('Webhook service', () => {
         .spyOn(Logger.prototype, 'error')
         .mockImplementation();
 
-      await webhookService.postWebhook(msg, url, '');
+      await webhookService.postWebhook(event, url, '');
 
       expect(httpServicePostSpy).toHaveBeenCalledTimes(1);
-      expect(httpServicePostSpy).toHaveBeenCalledWith(url, msg, {
+      expect(httpServicePostSpy).toHaveBeenCalledWith(url, event, {
         headers: {},
       });
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `Error sending event ${JSON.stringify(
-            msg,
-          )} to ${url}: Response not received. Error: ${errorMessageMocked}`,
+      expect(loggerErrorSpy).toHaveBeenCalledWith({
+        event: event,
+        message: expect.stringContaining(
+          `Error sending event to ${url}: Response not received. Error: ${errorMessageMocked}`,
         ),
-      );
+      });
     });
 
     it('should log an error message if request cannot be made', async () => {
       const url = 'http://localhost:4815';
-      const msg = {
+      const event = {
         chainId: '1',
         type: 'SAFE_CREATED' as TxServiceEventType,
         text: 'hello',
@@ -292,24 +292,23 @@ describe('Webhook service', () => {
         .spyOn(Logger.prototype, 'error')
         .mockImplementation();
 
-      await webhookService.postWebhook(msg, url, '');
+      await webhookService.postWebhook(event, url, '');
 
       expect(httpServicePostSpy).toHaveBeenCalledTimes(1);
-      expect(httpServicePostSpy).toHaveBeenCalledWith(url, msg, {
+      expect(httpServicePostSpy).toHaveBeenCalledWith(url, event, {
         headers: {},
       });
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `Error sending event ${JSON.stringify(
-            msg,
-          )} to ${url}: ${errorMessage}`,
+      expect(loggerErrorSpy).toHaveBeenCalledWith({
+        event: event,
+        message: expect.stringContaining(
+          `Error sending event to ${url}: ${errorMessage}`,
         ),
-      );
+      });
     });
 
-    it('should log an debug message if request is successful.', async () => {
+    it('should log a debug message if request is successful.', async () => {
       const url = 'http://localhost:4815';
-      const msg = {
+      const event = {
         chainId: '1',
         type: 'SAFE_CREATED' as TxServiceEventType,
         text: 'hello',
@@ -329,17 +328,18 @@ describe('Webhook service', () => {
         .spyOn(Logger.prototype, 'debug')
         .mockImplementation();
 
-      await webhookService.postWebhook(msg, url, '');
+      await webhookService.postWebhook(event, url, '');
 
       expect(httpServicePostSpy).toHaveBeenCalledTimes(1);
-      expect(httpServicePostSpy).toHaveBeenCalledWith(url, msg, {
+      expect(httpServicePostSpy).toHaveBeenCalledWith(url, event, {
         headers: {},
       });
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /Success sending event \{.*\} to http:\/\/localhost:4815\: 204 - null \[startTime: \d+, endTime: \d+, responseTime: \d+ms\]/,
+      expect(loggerErrorSpy).toHaveBeenCalledWith({
+        event: event,
+        message: expect.stringMatching(
+          /Success sending event to http:\/\/localhost:4815\: 204 - null \[startTime: \d+, endTime: \d+, responseTime: \d+ms\]/,
         ),
-      );
+      });
     });
   });
 });

--- a/src/routes/webhook/webhook.service.spec.ts
+++ b/src/routes/webhook/webhook.service.spec.ts
@@ -33,12 +33,12 @@ describe('Webhook service', () => {
 
       let results = await webhookService.getCachedActiveWebhooks();
       expect(results).toEqual(expected);
-      expect(findAllActiveSpy).toBeCalledTimes(1);
+      expect(findAllActiveSpy).toHaveBeenCalledTimes(1);
 
       // As it's cached, it shouldn't be called again
       results = await webhookService.getCachedActiveWebhooks();
       expect(results).toEqual(expected);
-      expect(findAllActiveSpy).toBeCalledTimes(1);
+      expect(findAllActiveSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/routes/webhook/webhook.service.ts
+++ b/src/routes/webhook/webhook.service.ts
@@ -96,7 +96,7 @@ export class WebhookService {
             // Response received status code but status code not 2xx
             const responseData = this.parseResponseData(error.response.data);
             this.logger.error({
-              message: `Error sending event`,
+              message: 'Error sending event',
               event: parsedMessage,
               httpRequest: {
                 url: url,
@@ -139,7 +139,7 @@ export class WebhookService {
         const elapsedTime = endTime - startTime;
         const responseData = this.parseResponseData(response.data);
         this.logger.debug({
-          message: `Success sending event`,
+          message: 'Success sending event',
           event: parsedMessage,
           httpRequest: {
             url: url,

--- a/src/routes/webhook/webhook.service.ts
+++ b/src/routes/webhook/webhook.service.ts
@@ -97,37 +97,43 @@ export class WebhookService {
             const responseData = this.parseResponseData(error.response.data);
             this.logger.error({
               message: 'Error sending event',
-              event: parsedMessage,
-              httpRequest: {
-                url: url,
-                startTime: startTime,
-              },
-              httpResponse: {
-                data: responseData,
-                statusCode: error.response.status,
+              messageContext: {
+                event: parsedMessage,
+                httpRequest: {
+                  url: url,
+                  startTime: startTime,
+                },
+                httpResponse: {
+                  data: responseData,
+                  statusCode: error.response.status,
+                },
               },
             });
           } else if (error.request !== undefined) {
             // Request was made but response was not received
             this.logger.error({
               message: `Error sending event: Response not received. Error: ${error.message}`,
-              event: parsedMessage,
-              httpRequest: {
-                url: url,
-                startTime: startTime,
+              messageContext: {
+                event: parsedMessage,
+                httpRequest: {
+                  url: url,
+                  startTime: startTime,
+                },
+                httpResponse: null,
               },
-              httpResponse: null,
             });
           } else {
             // Cannot make request
             this.logger.error({
               message: `Error sending event: ${error.message}`,
-              event: parsedMessage,
-              httpRequest: {
-                url: url,
-                startTime: startTime,
+              messageContext: {
+                event: parsedMessage,
+                httpRequest: {
+                  url: url,
+                  startTime: startTime,
+                },
+                httpResponse: null,
               },
-              httpResponse: null,
             });
           }
           return of(undefined);
@@ -140,16 +146,18 @@ export class WebhookService {
         const responseData = this.parseResponseData(response.data);
         this.logger.debug({
           message: 'Success sending event',
-          event: parsedMessage,
-          httpRequest: {
-            url: url,
-            startTime: startTime,
-            endTime: endTime,
-          },
-          httpResponse: {
-            data: responseData,
-            statusCode: response.status,
-            elapsedTimeMs: elapsedTime,
+          messageContext: {
+            event: parsedMessage,
+            httpRequest: {
+              url: url,
+              startTime: startTime,
+              endTime: endTime,
+            },
+            httpResponse: {
+              data: responseData,
+              statusCode: response.status,
+              elapsedTimeMs: elapsedTime,
+            },
           },
         });
       }

--- a/src/routes/webhook/webhook.service.ts
+++ b/src/routes/webhook/webhook.service.ts
@@ -70,6 +70,9 @@ export class WebhookService {
   }
 
   parseResponseData(responseData: any): string {
+    if (typeof responseData === 'string') {
+      return responseData;
+    }
     let dataStr: string;
     try {
       dataStr = JSON.stringify(responseData);
@@ -93,20 +96,38 @@ export class WebhookService {
             // Response received status code but status code not 2xx
             const responseData = this.parseResponseData(error.response.data);
             this.logger.error({
-              message: `Error sending event to ${url}: ${error.response.status} ${error.response.statusText} - ${responseData}`,
+              message: `Error sending event`,
               event: parsedMessage,
+              httpRequest: {
+                url: url,
+                startTime: startTime,
+              },
+              httpResponse: {
+                data: responseData,
+                statusCode: error.response.status,
+              },
             });
           } else if (error.request !== undefined) {
             // Request was made but response was not received
             this.logger.error({
-              message: `Error sending event to ${url}: Response not received. Error: ${error.message}`,
+              message: `Error sending event: Response not received. Error: ${error.message}`,
               event: parsedMessage,
+              httpRequest: {
+                url: url,
+                startTime: startTime,
+              },
+              httpResponse: null,
             });
           } else {
             // Cannot make request
             this.logger.error({
-              message: `Error sending event to ${url}: ${error.message}`,
+              message: `Error sending event: ${error.message}`,
               event: parsedMessage,
+              httpRequest: {
+                url: url,
+                startTime: startTime,
+              },
+              httpResponse: null,
             });
           }
           return of(undefined);
@@ -118,8 +139,18 @@ export class WebhookService {
         const elapsedTime = endTime - startTime;
         const responseData = this.parseResponseData(response.data);
         this.logger.debug({
-          message: `Success sending event to ${url}: ${response.status} - ${responseData} [startTime: ${startTime}, endTime: ${endTime}, responseTime: ${elapsedTime}ms]`,
+          message: `Success sending event`,
           event: parsedMessage,
+          httpRequest: {
+            url: url,
+            startTime: startTime,
+            endTime: endTime,
+          },
+          httpResponse: {
+            data: responseData,
+            statusCode: response.status,
+            elapsedTimeMs: elapsedTime,
+          },
         });
       }
       return response;

--- a/src/routes/webhook/webhook.service.ts
+++ b/src/routes/webhook/webhook.service.ts
@@ -86,26 +86,28 @@ export class WebhookService {
   ): Promise<AxiosResponse | undefined> {
     const headers = authorization ? { Authorization: authorization } : {};
     const startTime = Date.now();
-    const strMessage = JSON.stringify(parsedMessage);
     return firstValueFrom(
       this.httpService.post(url, parsedMessage, { headers }).pipe(
         catchError((error: AxiosError) => {
           if (error.response !== undefined) {
             // Response received status code but status code not 2xx
             const responseData = this.parseResponseData(error.response.data);
-            this.logger.error(
-              `Error sending event ${strMessage} to ${url}: ${error.response.status} ${error.response.statusText} - ${responseData}`,
-            );
+            this.logger.error({
+              message: `Error sending event to ${url}: ${error.response.status} ${error.response.statusText} - ${responseData}`,
+              event: parsedMessage,
+            });
           } else if (error.request !== undefined) {
             // Request was made but response was not received
-            this.logger.error(
-              `Error sending event ${strMessage} to ${url}: Response not received. Error: ${error.message}`,
-            );
+            this.logger.error({
+              message: `Error sending event to ${url}: Response not received. Error: ${error.message}`,
+              event: parsedMessage,
+            });
           } else {
             // Cannot make request
-            this.logger.error(
-              `Error sending event ${strMessage} to ${url}: ${error.message}`,
-            );
+            this.logger.error({
+              message: `Error sending event to ${url}: ${error.message}`,
+              event: parsedMessage,
+            });
           }
           return of(undefined);
         }),
@@ -115,9 +117,10 @@ export class WebhookService {
         const endTime = Date.now();
         const elapsedTime = endTime - startTime;
         const responseData = this.parseResponseData(response.data);
-        this.logger.debug(
-          `Success sending event ${strMessage} to ${url}: ${response.status} - ${responseData} [startTime: ${startTime}, endTime: ${endTime}, responseTime: ${elapsedTime}ms]`,
-        );
+        this.logger.debug({
+          message: `Success sending event to ${url}: ${response.status} - ${responseData} [startTime: ${startTime}, endTime: ${endTime}, responseTime: ${elapsedTime}ms]`,
+          event: parsedMessage,
+        });
       }
       return response;
     });


### PR DESCRIPTION
- Closes #217
- JsonLogger can receive now a `message: string` or an object so attributes will be added to the JSON

Example of the new log format:

```js
{
        message: "Success sending event",
        messageContext: { 
          event: parsedMessage,
          httpRequest: {
            url: url,
            startTime: startTime,
            endTime: endTime,
          },
          httpResponse: {
            data: responseData,
            statusCode: response.status,
            elapsedTimeMs: elapsedTime
          }
      }
}
```