### PR TITLE
Fix e2e tests timeouts problems

### DIFF
--- a/test/events.e2e-spec.ts
+++ b/test/events.e2e-spec.ts
@@ -29,7 +29,7 @@ describe('Events handling', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-  });
+  }, 10000);
 
   afterEach(async () => {
     // Nest.js Shutdown hooks are not triggered


### PR DESCRIPTION
By default, the hook [beforeEach has a timeout of 500ms](https://jestjs.io/docs/api#beforeeachfn-timeout). 

It seems that in some cases in the github CI it is taking more time to set up the connections needed for the test.

According to the e2e test [app.e2e-spec.ts the timeout is set to 10sec](https://github.com/safe-global/safe-events-service/blob/bb143b0fa9a4c0b11a9a577bcaf5d64dfb7b8a57/test/app.e2e-spec.ts#L29).