### PR TITLE
Fix typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you want to integrate with the events service, you need to:
 - Endpoint need to answer with:
   - `HTTP 202` status
   - Nothing in the body.
-  - It should answer **as soon as posible**, as events service will timeout in 2 seconds, if multiple timeouts are detected **service will stop sending requests** to your endpoint. So you should receive the event, return a HTTP response and then act upon it.
+  - It should answer **as soon as possible**, as events service will timeout in 2 seconds, if multiple timeouts are detected **service will stop sending requests** to your endpoint. So you should receive the event, return a HTTP response and then act upon it.
   - Configuring HTTP Basic Auth in your endpoint is recommended so a malicious user cannot post fake events to your service.
 
 ## Events supported


### PR DESCRIPTION
Original text: "It should answer as soon as posible"
Corrected text: "It should answer as soon as possible"
Explanation:
The word "posible" was a typo, which was corrected to "possible."
This change enhances the clarity and professionalism of the documentation, ensuring it is free of errors and more accessible to readers.
Change Details:
Lines affected: Line 32 in the README.md file.
Number of changes: One deletion (incorrect text) and one addition (corrected text).
This update adheres to best practices for maintaining high-quality documentation and makes the instructions more precise for users integrating with the events service.






